### PR TITLE
Spin up Solr server at beginning of cucumber run and kill it at the end. 

### DIFF
--- a/lib/sunspot_test/cucumber.rb
+++ b/lib/sunspot_test/cucumber.rb
@@ -1,27 +1,25 @@
 require 'net/http'
 
-Before("@searchrunning") do
-  $sunspot = true
-end
-
-Before("@search") do
-  unless $sunspot
-    $sunspot = Sunspot::Rails::Server.new
+AfterConfiguration do |config|
+    sunspot = Sunspot::Rails::Server.new
+    
     pid = fork do
       STDERR.reopen('/dev/null')
       STDOUT.reopen('/dev/null')
-      $sunspot.run
+      sunspot.run
     end
+    
     # shut down the Solr server
     at_exit { Process.kill('TERM', pid) }
     SunspotTestHelper.wait_until_solr_starts
-  end
-  
+end
+
+Before("@search") do
   Sunspot.remove_all!
   Sunspot.commit
 end
 
-AfterStep('@search') do
+AfterStep("@search") do
   Sunspot.commit
 end
 


### PR DESCRIPTION
Spin up Solr server at beginning of cucumber run and kill it at the end. Using the @search tags for only maintaining the Solr index correctly.
