### PR TITLE
Use existing server, corrected.

### DIFF
--- a/lib/sunspot_test.rb
+++ b/lib/sunspot_test.rb
@@ -22,7 +22,7 @@ module SunspotTest
     end
 
     def start_sunspot_server
-      unless @running
+      unless solr_running?
         pid = fork do
           STDERR.reopen("/dev/null")
           STDOUT.reopen("/dev/null")
@@ -31,7 +31,6 @@ module SunspotTest
 
         at_exit { Process.kill("TERM", pid) }
 
-        @running = true
         wait_until_solr_starts
       end
     end

--- a/spec/sunspot_test_spec.rb
+++ b/spec/sunspot_test_spec.rb
@@ -30,7 +30,7 @@ describe SunspotTest do
 
   describe ".start_sunspot_server" do
     context "if server is already started" do
-      before(:each) { SunspotTest.server = true }
+      before(:each) { SunspotTest.stub!(:solr_running? => true) }
 
       it "does not try to spin up another server" do
         Kernel.should_not_receive(:fork)


### PR DESCRIPTION
This spec was failing for me.

SunspotTest
  .start_sunspot_server
    if server is already started
      does not try to spin up another server

The spec was setting SunspotTest.server = true.  I did not see any indication of how that would indicate another server was already running.  I replaced the instance var (@running) with a query (solr_running?).  We have to ask if a server is running, don't we?  

I also tested it manually by starting a server, `watch 'ps aux | grep [s]olr`, and running my features.  Prior to this change, another solr server was started.  After the change, the existing server was used.
