### PR TITLE
Rails 3.1 does not appear to ping correct server

### DIFF
--- a/lib/sunspot_test.rb
+++ b/lib/sunspot_test.rb
@@ -65,10 +65,18 @@ module SunspotTest
       end
       raise TimeOutError, "Solr failed to start after #{solr_startup_timeout} seconds" unless solr_running?
     end
+    
+    def solr_ping_uri
+      c = Sunspot::Rails.configuration
+      URI::HTTP.build(
+        :host => c.master_hostname,
+        :port => c.master_port,
+        :path => c.master_path
+      )
+    end
 
     def solr_running?
       begin
-        solr_ping_uri = URI.parse("#{Sunspot.session.config.solr.url}/ping")
         Net::HTTP.get(solr_ping_uri)
         true # Solr Running
       rescue


### PR DESCRIPTION
WIP: Switched to using Sunspot::Rails to get configuration to ensure that sunspot.yml settings are not ignored

I don't know if anyone else is experiencing this, but after updating to Rails 3.1 from Rails 2.3 sunspot_test no longer figures out the correct URL to ping - it gets the port wrong.

This commit fixes the issue for me, and uses Sunspot::Rails::Configuration to build the url rather than Sunspot.session.config - which seems to ignore sunspot.yml.

The test suite will need to be updated. I haven't done this as I am not certain of the future of sunspot_rails, and it would also require that Rails be added to the development dependencies.
