### PR TITLE
Fallback if not using with Rails. Closes #7.

### DIFF
--- a/lib/sunspot_test.rb
+++ b/lib/sunspot_test.rb
@@ -18,7 +18,11 @@ module SunspotTest
     end
 
     def server
-      @server ||= Sunspot::Rails::Server.new
+      if defined?(Rails)
+        @server ||= Sunspot::Rails::Server.new
+      else
+        @server ||= Sunspot::Solr::Server.new
+      end
     end
 
     def start_sunspot_server


### PR DESCRIPTION
Easy fix here, Sunspot::Rails::Server is a subclass of Sunspot::Solr::Server, which we can use if we're not in a Rails environment. (With this patch, sunspot_test is working for me on my Sinatra app).
