### PR TITLE
Fix for minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,7 @@ source 'http://rubygems.org'
 group :development do
   gem "jeweler"
   gem "rspec"
+  gem "sunspot"
+  gem "sunspot_rails"
+  gem "sunspot_solr"
 end

--- a/lib/sunspot_test.rb
+++ b/lib/sunspot_test.rb
@@ -7,6 +7,7 @@ module SunspotTest
 
     attr_writer :solr_startup_timeout
     attr_writer :server
+    attr_accessor :custom_module_name
 
     def solr_startup_timeout
       @solr_startup_timeout || 15
@@ -29,7 +30,7 @@ module SunspotTest
           server.run
         end
 
-        at_exit { Process.kill("TERM", pid) }
+        (custom_module_name ? eval(custom_module_name) : self).send(:set_kill_server_callback) { Process.kill("TERM", pid) }
 
         wait_until_solr_starts
       end
@@ -73,6 +74,10 @@ module SunspotTest
       rescue
         false # Solr Not Running
       end
+    end
+
+    def set_kill_server_callback(&block)
+      at_exit &block
     end
   end
 end

--- a/lib/sunspot_test/minitest.rb
+++ b/lib/sunspot_test/minitest.rb
@@ -1,0 +1,13 @@
+if Gem::Version.new(MiniTest::Unit::VERSION) < Gem::Version.new('2.11.1')
+  raise "Detected MiniTest #{MiniTest::Unit::VERSION}; must use version 2.11.1 or greater"
+end
+
+SunspotTest.module_eval do
+  class << self
+    def set_kill_server_callback(&block)
+      MiniTest::Unit.after_tests &block
+    end
+  end
+end
+
+require 'sunspot_test/test_unit'

--- a/lib/sunspot_test/minitest.rb
+++ b/lib/sunspot_test/minitest.rb
@@ -2,12 +2,16 @@ if Gem::Version.new(MiniTest::Unit::VERSION) < Gem::Version.new('2.11.1')
   raise "Detected MiniTest #{MiniTest::Unit::VERSION}; must use version 2.11.1 or greater"
 end
 
-SunspotTest.module_eval do
-  class << self
-    def set_kill_server_callback(&block)
-      MiniTest::Unit.after_tests &block
+module SunspotTest
+  module MiniTest
+    class << self
+      def set_kill_server_callback(&block)
+        ::MiniTest::Unit.after_tests &block
+      end
     end
   end
 end
+
+SunspotTest.custom_module_name = 'SunspotTest::MiniTest'
 
 require 'sunspot_test/test_unit'

--- a/spec/sunspot_test/minitest_spec.rb
+++ b/spec/sunspot_test/minitest_spec.rb
@@ -1,0 +1,29 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe "minitest.rb" do
+  describe "with MiniTest::Unit version that's too old" do
+    it "raises an exception" do
+      stub_const("MiniTest::Unit::VERSION", '2.10.9')
+      expect {
+        load File.expand_path(File.dirname(__FILE__) + '/../../lib/sunspot_test/minitest.rb')
+      }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "with valid MiniTest version" do
+    it "modifies behavior of SunspotTest.set_kill_server_callback (to call MiniTest::Unit.after_tests)" do
+      stub_const('MiniTest::Unit', Class.new do
+        def self.after_tests(&block)
+          yield
+        end
+      end)
+      stub_const('MiniTest::Unit::VERSION', '2.11.1')
+
+      block_obj = double
+      block_obj.should_receive(:foo)
+      SunspotTest.stub!(:setup_solr)
+      load File.expand_path(File.dirname(__FILE__) + '/../../lib/sunspot_test/minitest.rb')
+      SunspotTest.set_kill_server_callback { block_obj.foo }
+    end
+  end
+end

--- a/spec/sunspot_test/minitest_spec.rb
+++ b/spec/sunspot_test/minitest_spec.rb
@@ -1,6 +1,10 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "minitest.rb" do
+  after(:all) do
+    SunspotTest.custom_module_name = nil
+  end
+
   describe "with MiniTest::Unit version that's too old" do
     it "raises an exception" do
       stub_const("MiniTest::Unit::VERSION", '2.10.9')
@@ -10,8 +14,8 @@ describe "minitest.rb" do
     end
   end
 
-  describe "with valid MiniTest version" do
-    it "modifies behavior of SunspotTest.set_kill_server_callback (to call MiniTest::Unit.after_tests)" do
+  describe "SunspotTest::MiniTest.set_kill_server_callback" do
+    it "should call MiniTest::Unit.after_tests (instead of Kernel#at_exit)" do
       stub_const('MiniTest::Unit', Class.new do
         def self.after_tests(&block)
           yield
@@ -23,7 +27,7 @@ describe "minitest.rb" do
       block_obj.should_receive(:foo)
       SunspotTest.stub!(:setup_solr)
       load File.expand_path(File.dirname(__FILE__) + '/../../lib/sunspot_test/minitest.rb')
-      SunspotTest.set_kill_server_callback { block_obj.foo }
+      SunspotTest::MiniTest.set_kill_server_callback { block_obj.foo }
     end
   end
 end

--- a/spec/sunspot_test/minitest_spec.rb
+++ b/spec/sunspot_test/minitest_spec.rb
@@ -1,11 +1,17 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "minitest.rb" do
+  before(:each) do
+    stub_const('MiniTest::Unit', Class.new)
+    stub_const("MiniTest::Unit::VERSION", '2.11.1')
+    SunspotTest.stub!(:setup_solr)
+  end
+
   after(:all) do
     SunspotTest.custom_module_name = nil
   end
 
-  describe "with MiniTest::Unit version that's too old" do
+  context "with MiniTest::Unit version that's too old" do
     it "raises an exception" do
       stub_const("MiniTest::Unit::VERSION", '2.10.9')
       expect {
@@ -14,20 +20,27 @@ describe "minitest.rb" do
     end
   end
 
-  describe "SunspotTest::MiniTest.set_kill_server_callback" do
-    it "should call MiniTest::Unit.after_tests (instead of Kernel#at_exit)" do
-      stub_const('MiniTest::Unit', Class.new do
-        def self.after_tests(&block)
-          yield
+  describe "SunspotTest::MiniTest" do
+    describe ".set_kill_server_callback" do
+      it "should call MiniTest::Unit.after_tests (instead of Kernel#at_exit)" do
+        MiniTest::Unit.class_eval do
+          def self.after_tests(&block)
+            yield
+          end
         end
-      end)
-      stub_const('MiniTest::Unit::VERSION', '2.11.1')
 
-      block_obj = double
-      block_obj.should_receive(:foo)
-      SunspotTest.stub!(:setup_solr)
-      load File.expand_path(File.dirname(__FILE__) + '/../../lib/sunspot_test/minitest.rb')
-      SunspotTest::MiniTest.set_kill_server_callback { block_obj.foo }
+        block_obj = double
+        block_obj.should_receive(:foo)
+        #SunspotTest.stub!(:setup_solr)
+        load File.expand_path(File.dirname(__FILE__) + '/../../lib/sunspot_test/minitest.rb')
+        SunspotTest::MiniTest.set_kill_server_callback { block_obj.foo }
+      end
     end
   end
+
+  it "sets SunspotTest.custom_module_name to 'SunspotTest::MiniTest'" do
+    SunspotTest.should_receive(:custom_module_name=).with('SunspotTest::MiniTest')
+    load File.expand_path(File.dirname(__FILE__) + '/../../lib/sunspot_test/minitest.rb')
+  end
+
 end

--- a/spec/sunspot_test_spec.rb
+++ b/spec/sunspot_test_spec.rb
@@ -30,7 +30,7 @@ describe SunspotTest do
 
   describe ".start_sunspot_server" do
     context "if server is already started" do
-      before(:each) { SunspotTest.stub!(:solr_running? => true) }
+      before(:each) { SunspotTest.stub!(:solr_running?).and_return(true) }
 
       it "does not try to spin up another server" do
         Kernel.should_not_receive(:fork)
@@ -154,6 +154,24 @@ describe SunspotTest do
 
           lambda { SunspotTest.send(:wait_until_solr_starts) }.should_not raise_error
         end
+      end
+    end
+
+    describe "killing the server" do
+      it "should call the default 'set_kill_server_callback' method" do
+        SunspotTest.custom_module_name = nil
+        SunspotTest.stub!(:wait_until_solr_starts)
+        SunspotTest.should_receive(:set_kill_server_callback)
+        SunspotTest.start_sunspot_server
+      end
+
+      it "should call the custom module's 'set_kill_server_callback' method" do
+        mod = double('SunspotTest::CustomModule')
+        stub_const('SunspotTest::CustomModule', mod)
+        mod.should_receive(:set_kill_server_callback)
+        SunspotTest.custom_module_name = 'SunspotTest::CustomModule'
+        SunspotTest.stub!(:wait_until_solr_starts)
+        SunspotTest.start_sunspot_server
       end
     end
   end


### PR DESCRIPTION
When running a test with minitest, #at_exit gets called before the test runs, so the Solr server gets killed too soon.

MiniTest >= 2.11.1 has a fix for this. This change lets minitest users take advantage of the fix and prevents the server from dying until after the test is over.

(The README should be updated, too, I guess)