### PR TITLE
Use before :each instead of before :all for rspec

### DIFF
--- a/lib/sunspot_test/rspec.rb
+++ b/lib/sunspot_test/rspec.rb
@@ -1,11 +1,11 @@
 require 'sunspot_test'
 
 RSpec.configure do |c|
-  c.before(:all) do
+  c.before(:each) do
     SunspotTest.stub
   end
   
-  c.before(:all, :search => true) do
+  c.before(:each, :search => true) do
     SunspotTest.setup_solr
     Sunspot.remove_all!
     Sunspot.commit


### PR DESCRIPTION
As it was, solr was not clearing between specs. Also, if you one spec that required search and another that didn't within the same block you would search when you do not want it depending on the order the specs are run in.
