### PR TITLE
Consider a 503 response as Solr not running

### DIFF
--- a/lib/sunspot_test.rb
+++ b/lib/sunspot_test.rb
@@ -68,8 +68,9 @@ module SunspotTest
     def solr_running?
       begin
         solr_ping_uri = URI.parse("#{Sunspot.session.config.solr.url}/ping")
-        Net::HTTP.get(solr_ping_uri)
-        true # Solr Running
+        res = Net::HTTP.get_response(solr_ping_uri)
+        # Solr will return 503 codes when it's starting up
+        res.code != '503'
       rescue
         false # Solr Not Running
       end

--- a/spec/sunspot_test_spec.rb
+++ b/spec/sunspot_test_spec.rb
@@ -135,7 +135,7 @@ describe SunspotTest do
     describe ".solr_running" do
       context "if solr is running" do
         before do
-          Net::HTTP.stub(get:true)
+          Net::HTTP.stub(get_response:double(code: '200'))
         end
 
         it "returns true" do
@@ -148,6 +148,17 @@ describe SunspotTest do
           expect(SunspotTest.send(:solr_running?)).to eq(false)
         end
       end
+
+      context "if solr is starting up" do
+        before do
+          Net::HTTP.stub(get_response:double(code: '503'))
+        end
+
+        it "returns false" do
+          expect(SunspotTest.send(:solr_running?)).to eq(false)
+        end
+      end
+
     end
     describe ".wait_until_solr_starts" do
       context "if solr never starts" do


### PR DESCRIPTION
Using:

```
sunspot (2.0.0)
sunspot_rails (2.0.0)
sunspot_solr (2.2.0)
sunspot_test (0.4.0)
```

When running cucumber tests, the first few will fail because:

```
  RSolr::Error::Http - 503 Service Unavailable
  Error:     {msg=SolrCore is loading,code=503}

  URI: http://localhost:8983/solr/test/update?wt=ruby
```

This PR changes the `solr_running?` check to consider a 503 response as not running. After this, my tests correctly wait a couple seconds then work when Solr is ready.