### PR TITLE
Fix timeouts when trying to run current Sunspot Solr instances.

### DIFF
--- a/lib/sunspot_test.rb
+++ b/lib/sunspot_test.rb
@@ -67,7 +67,7 @@ module SunspotTest
 
     def solr_running?
       begin
-        solr_ping_uri = URI.parse("#{Sunspot.session.config.solr.url}/admin/ping")
+        solr_ping_uri = URI.parse("#{Sunspot.session.config.solr.url}/ping")
         res = Net::HTTP.get_response(solr_ping_uri)
         # Solr will return 503 codes when it's starting up
         res.code != '503'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 

--- a/spec/sunspot_test_spec.rb
+++ b/spec/sunspot_test_spec.rb
@@ -136,7 +136,7 @@ describe SunspotTest do
     describe ".solr_running" do
       context "if solr is running" do
         before do
-          expect(Net::HTTP).to receive(:get).and_return(true)
+          Net::HTTP.stub(get_response: double(code: '200'))
         end
 
         it "returns true" do

--- a/sunspot_test.gemspec
+++ b/sunspot_test.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "sunspot_solr"
-  s.add_runtime_dependency "sunspot_rails", ">= 1.2.1"
+  s.add_runtime_dependency "sunspot_rails", ">= 2.1.1"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"


### PR DESCRIPTION
* Changes the ping url to http://<host>:<port>/solr/default/admin/ping